### PR TITLE
Enable specify second level domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ client = BacklogKit::Client.new(
 | ENV Variable | Description |
 | :----------- | :---------- |
 | `BACKLOG_SPACE_ID` | Your Backlog SPACE ID. |
+| `BACKLOG_SECOND_LEVEL_DOMAIN` | Your Backlog SECOND LEVEL DOMAIN. |
 | `BACKLOG_TOP_LEVEL_DOMAIN` | Your Backlog TOP LEVEL DOMAIN. |
 | `BACKLOG_API_KEY` | Your Backlog API KEY. |
 | `BACKLOG_OAUTH_CLIENT_ID` | CLIENT ID of your Backlog application. |

--- a/lib/backlog_kit/client.rb
+++ b/lib/backlog_kit/client.rb
@@ -43,6 +43,7 @@ module BacklogKit
 
     attr_accessor(
       :space_id,
+      :second_level_domain,
       :top_level_domain,
       :api_key,
       :client_id,
@@ -57,18 +58,20 @@ module BacklogKit
     #
     # @param options [Hash] Initialize options
     # @option options [String] :space_id Backlog space id
+    # @option options [String] :second_level_domain Backlog second level domain
     # @option options [String] :top_level_domain Backlog top level domain
     # @option options [String] :api_key Backlog api key
     # @option options [String] :client_id Backlog OAuth client id
     # @option options [String] :client_secret Backlog OAuth client secret
     # @option options [String] :refresh_token Backlog OAuth refresh token
     def initialize(options = {})
-      @space_id         = ENV['BACKLOG_SPACE_ID']
-      @top_level_domain = ENV['BACKLOG_TOP_LEVEL_DOMAIN'] || 'jp'
-      @api_key          = ENV['BACKLOG_API_KEY']
-      @client_id        = ENV['BACKLOG_OAUTH_CLIENT_ID']
-      @client_secret    = ENV['BACKLOG_OAUTH_CLIENT_SECRET']
-      @refresh_token    = ENV['BACKLOG_OAUTH_REFRESH_TOKEN']
+      @space_id            = ENV['BACKLOG_SPACE_ID']
+      @second_level_domain = ENV['BACKLOG_SECOND_LEVEL_DOMAIN'] || 'backlog'
+      @top_level_domain    = ENV['BACKLOG_TOP_LEVEL_DOMAIN'] || 'jp'
+      @api_key             = ENV['BACKLOG_API_KEY']
+      @client_id           = ENV['BACKLOG_OAUTH_CLIENT_ID']
+      @client_secret       = ENV['BACKLOG_OAUTH_CLIENT_SECRET']
+      @refresh_token       = ENV['BACKLOG_OAUTH_REFRESH_TOKEN']
 
       options.each do |key, value|
         instance_variable_set(:"@#{key}", value)
@@ -152,7 +155,7 @@ module BacklogKit
     end
 
     def host
-      "https://#{space_id}.backlog.#{top_level_domain}"
+      "https://#{space_id}.#{second_level_domain}.#{top_level_domain}"
     end
 
     def request_headers


### PR DESCRIPTION
thank you for awesome gem.
i'd like to use backlog_kit on `*.backlogtool.com` spaces.

what do you think?

example:
```
client = BacklogKit::Client.new(
  space_id: '***',
  second_level_domain: 'backlogtool',
  top_level_domain: 'com',
)
```